### PR TITLE
Fixing run_until_passivate function in dynamic runner (#81)

### DIFF
--- a/include/cadmium/engine/pdevs_dynamic_runner.hpp
+++ b/include/cadmium/engine/pdevs_dynamic_runner.hpp
@@ -89,13 +89,7 @@ namespace cadmium {
                  * @brief runUntilPassivate starts the simulation and stops when there is no next internal event to happen.
                  */
                 void run_until_passivate() {
-                    LOGGER::template log<cadmium::logger::logger_info, cadmium::logger::run_info>("Starting run");
-                    while (_next != std::numeric_limits<TIME>::infinity()) {
-                        LOGGER::template log<cadmium::logger::logger_global_time, TIME>(_next);
-                        _top_coordinator.advance_simulation(_next);
-                        _next = _top_coordinator.next();
-                    }
-                    LOGGER::template log<cadmium::logger::logger_info, cadmium::logger::run_info>("Finished run");
+                    run_until(std::numeric_limits<TIME>::infinity());
                 }
             };
         }

--- a/include/cadmium/engine/pdevs_runner.hpp
+++ b/include/cadmium/engine/pdevs_runner.hpp
@@ -92,10 +92,8 @@ namespace cadmium {
              * @brief runUntilPassivate starts the simulation and stops when there is no next internal event to happen.
              */
             void run_until_passivate() {
-                LOGGER::template log<cadmium::logger::logger_info, cadmium::logger::run_info>("Starting run");
                 static_assert(std::numeric_limits<TIME>::has_infinity, "TIME datatype has no infinity defined");
                 run_until(std::numeric_limits<TIME>::infinity());
-                LOGGER::template log<cadmium::logger::logger_info, cadmium::logger::run_info>("Finished run");
             }
         };
     }


### PR DESCRIPTION
* Fixing run_until_passivate function in dynamic runner, it wasn't calling collect_outputs 

* removing duplicate log in Runner